### PR TITLE
Add CPU and memory widgets to eww bar

### DIFF
--- a/eww/eww.scss
+++ b/eww/eww.scss
@@ -22,6 +22,9 @@ $green: #98971a;
   padding: 4px 10px;
 }
 
+.cpu { color: $accent; }
+.mem { color: $accent2; }
+
 .ws {
   .ws-btn {
     background: $bg-alt;

--- a/eww/eww.yuck
+++ b/eww/eww.yuck
@@ -17,6 +17,8 @@
     (box :halign "center"
       (label :class "title" :text "Hyprland x EWW"))
     (box :halign "end" :spacing 14
+      (cpu)
+      (mem)
       (net)
       (volume)
       (battery)
@@ -38,6 +40,18 @@
 (defwidget net []
   (box :class "pill"
     (label :text netinfo)))
+
+;; ---------- CPU ----------
+(defpoll cpu :interval "2s" "bash ~/.config/eww/scripts/cpu.sh")
+(defwidget cpu []
+  (box :class "pill cpu"
+    (label :text cpu)))
+
+;; ---------- Memoria ----------
+(defpoll mem :interval "5s" "bash ~/.config/eww/scripts/mem.sh")
+(defwidget mem []
+  (box :class "pill mem"
+    (label :text mem)))
 
 ;; ---------- Volumen ----------
 (defpoll vol :interval "1s" "bash ~/.config/eww/scripts/vol.sh")

--- a/eww/scripts/cpu.sh
+++ b/eww/scripts/cpu.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cpu=$(awk '/^cpu /{u=$2+$4; t=$2+$4+$5; printf("%.0f", u*100/t)}' /proc/stat)
+echo "󰍛 ${cpu}%"

--- a/eww/scripts/mem.sh
+++ b/eww/scripts/mem.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mem=$(free -m | awk '/^Mem:/ {printf("%.0f", $3/$2*100)}')
+echo "󰘚 ${mem}%"


### PR DESCRIPTION
## Summary
- show system CPU usage via new script and widget
- display memory usage with dedicated script and widget
- style CPU and memory modules in bar

## Testing
- `bash eww/scripts/cpu.sh`
- `bash eww/scripts/mem.sh`
- `eww reload` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6897f215056c832388c9b7939affa926